### PR TITLE
fix: tsconfig报错，修复硬编码路径

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,5 +69,5 @@
     "uuidv",
     "varchar"
   ],
-  "typescript.native-preview.tsdk": "/Users/zheqi/Documents/project/clhoria-template/node_modules/@typescript/native-preview"
+  "typescript.native-preview.tsdk": "node_modules/@typescript/native-preview"
 }


### PR DESCRIPTION
.vscode/settings.json 里 typescript.native-preview.tsdk 写成了绝对路径，其他的用户找不到目录，VS Code 报错并回退到默认 TS